### PR TITLE
add missing examples

### DIFF
--- a/_sources/geodcat-stac-earthcode/workflows/examples.yaml
+++ b/_sources/geodcat-stac-earthcode/workflows/examples.yaml
@@ -46,7 +46,7 @@
     calculation.
   snippets:
    - language: json
-     ref: https://raw.githubusercontent.com/ESA-EarthCODE/open-science-catalog-metadata-staging/aae6a404e1140464a700302f2980e7ff17fe9422/workflows/kindgrove-mangrove-biomass-workflow/record.json
+     ref: https://esa-earthcode.github.io/open-science-catalog-metadata-staging/workflows/kindgrove-mangrove-biomass-workflow/record.json
      base-uri: https://ogc.org/demo/ospd/
 
 - title: Coastal Vulnerability Index (CVI) Workflow
@@ -54,5 +54,13 @@
     An automated, reproducible workflow for calculating the Coastal Vulnerability Index (CVI). This system generates coastal transects, fetches satellite data (DEM, Land Cover), computes physical parameters, and classifies coastal risk based on the USGS/NOAA methodology.\n\nThe workflow is implemented in Common Workflow Language (CWL) and runs inside a Docker container, ensuring it can be executed anywhere—from a local laptop to a High-Performance Computing (HPC) cluster or JupyterHub.
   snippets:
    - language: json
-     ref: https://raw.githubusercontent.com/ESA-EarthCODE/open-science-catalog-metadata-staging/887242c4b132f6bc757ed36cf0d78a1bd0f608c7/workflows/cvi-workflow/record.json
+     ref: https://esa-earthcode.github.io/open-science-catalog-metadata-staging/workflows/cvi-workflow/record.json
+     base-uri: https://ogc.org/demo/ospd/
+
+- title: ML4Floods Inference for Flood Extent Estimation
+  content: |-
+   ML4Floods inference for flood extent estimation using a pre-trained model on Sentinel-2 or Landsat-9 data. This application is designed to process satellite imagery and delineate flood extents.
+  snippets:
+   - language: json
+     ref: https://esa-earthcode.github.io/open-science-catalog-metadata-staging/workflows/app-ml4floods/record.json
      base-uri: https://ogc.org/demo/ospd/


### PR DESCRIPTION
This PR adds the CVI and Mangroove workflows as examples to the building block.
We added the actual records in a PR to  OSC-staging - https://github.com/ESA-EarthCODE/open-science-catalog-metadata-staging/pull/212/files . Locally, the bb build works and the tests pass.

Since we auto generated the records, I think we should merge them after they are reviewed by the respective teams.  Then I can change the links here and open the PR.

Edit: Adding the ml4floods example as well